### PR TITLE
Use requests session instead of session.

### DIFF
--- a/apiclient/client.py
+++ b/apiclient/client.py
@@ -1,6 +1,6 @@
 import copy
 import logging
-from typing import Optional, Type
+from typing import Any, Optional, Type
 
 from apiclient.authentication_methods import BaseAuthenticationMethod, NoAuthentication
 from apiclient.request_formatters import BaseRequestFormatter, NoOpRequestFormatter
@@ -25,12 +25,21 @@ class APIClient:
         self._default_headers = {}
         self._default_query_params = {}
         self._default_username_password_authentication = None
+        # A session needs to live at this client level so that all
+        # request strategies have access to the same session.
+        self._session = None
 
         # Set client strategies
         self.set_authentication_method(authentication_method)
         self.set_response_handler(response_handler)
         self.set_request_formatter(request_formatter)
         self.set_request_strategy(RequestStrategy())
+
+    def get_session(self) -> Any:
+        return self._session
+
+    def set_session(self, session: Any):
+        self._session = session
 
     def set_authentication_method(self, authentication_method: BaseAuthenticationMethod):
         if not isinstance(authentication_method, BaseAuthenticationMethod):

--- a/apiclient/client.py
+++ b/apiclient/client.py
@@ -1,4 +1,3 @@
-import copy
 import logging
 from typing import Any, Optional, Type
 
@@ -48,6 +47,9 @@ class APIClient:
             )
         self._authentication_method = authentication_method
 
+    def get_authentication_method(self) -> BaseAuthenticationMethod:
+        return self._authentication_method
+
     def get_response_handler(self) -> Type[BaseResponseHandler]:
         return self._response_handler
 
@@ -91,7 +93,14 @@ class APIClient:
 
     def clone(self):
         """Enable Prototype pattern on client."""
-        return copy.deepcopy(self)
+        new_client = APIClient(
+            authentication_method=self.get_authentication_method(),
+            response_handler=self.get_response_handler(),
+            request_formatter=self.get_request_formatter(),
+        )
+        new_client.set_request_strategy(self.get_request_strategy())
+        new_client.set_session(self.get_session())
+        return new_client
 
     def create(self, endpoint: str, data: dict, params: OptionalDict = None):
         """Provide backwards compatibility adaptor from create() -> post()."""

--- a/apiclient/request_strategies.py
+++ b/apiclient/request_strategies.py
@@ -41,25 +41,39 @@ class BaseRequestStrategy:
 
 
 class RequestStrategy(BaseRequestStrategy):
+    """Requests strategy that uses the `requests` lib with a `requests.session`."""
+
+    def set_client(self, client: "APIClient"):
+        super().set_client(client)
+        # Set a global `requests.session` on the parent client instance.
+        if self.get_session() is None:
+            self.set_session(requests.session())
+
+    def get_session(self):
+        return self.get_client().get_session()
+
+    def set_session(self, session: requests.Session):
+        self.get_client().set_session(session)
+
     def post(self, endpoint: str, data: dict, params: OptionalDict = None):
         """Send data and return response data from POST endpoint."""
-        return self._make_request(requests.post, endpoint, data=data, params=params)
+        return self._make_request(self.get_session().post, endpoint, data=data, params=params)
 
     def get(self, endpoint: str, params: OptionalDict = None):
         """Return response data from GET endpoint."""
-        return self._make_request(requests.get, endpoint, params=params)
+        return self._make_request(self.get_session().get, endpoint, params=params)
 
     def put(self, endpoint: str, data: dict, params: OptionalDict = None):
         """Send data to overwrite resource and return response data from PUT endpoint."""
-        return self._make_request(requests.put, endpoint, data=data, params=params)
+        return self._make_request(self.get_session().put, endpoint, data=data, params=params)
 
     def patch(self, endpoint: str, data: dict, params: OptionalDict = None):
         """Send data to update resource and return response data from PATCH endpoint."""
-        return self._make_request(requests.patch, endpoint, data=data, params=params)
+        return self._make_request(self.get_session().patch, endpoint, data=data, params=params)
 
     def delete(self, endpoint: str, params: OptionalDict = None):
         """Remove resource with DELETE endpoint."""
-        return self._make_request(requests.delete, endpoint, params=params)
+        return self._make_request(self.get_session().delete, endpoint, params=params)
 
     def _make_request(
         self,
@@ -74,6 +88,7 @@ class RequestStrategy(BaseRequestStrategy):
 
         Delegates response parsing to the response handler.
         """
+        print(">>>", request_method)
         try:
             response = request_method(
                 endpoint,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from typing import NamedTuple
 from unittest.mock import Mock, sentinel
 
 import pytest
+import requests
 import requests_mock
 import vcr
 
@@ -60,6 +61,7 @@ def mock_client():
     _mock_client.get_default_headers.return_value = {}
     _mock_client.get_default_username_password_authentication.return_value = None
     _mock_client.get_request_timeout.return_value = 30.0
+    _mock_client.get_session.return_value = requests.session()
     mock_request_formatter.format.return_value = {}
     _mock_client.get_request_formatter.return_value = mock_request_formatter
     mock_response_handler.get_request_data.return_value = sentinel.result

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,7 +5,7 @@ import pytest
 
 from apiclient import NoAuthentication
 from apiclient.client import LOG as client_logger
-from apiclient.client import BaseClient
+from apiclient.client import APIClient, BaseClient
 from apiclient.request_strategies import BaseRequestStrategy
 from tests.helpers import (
     MinimalClient,
@@ -163,3 +163,16 @@ def test_client_initialization_deprecation_warning_when_using_baseclient(caplog)
         "please use `APIClient` instead."
     )
     assert expected in caplog.messages
+
+
+def test_client_get_and_set_session():
+    client = APIClient()
+    client.set_session(sentinel.session)
+    assert client.get_session() == sentinel.session
+
+
+def test_client_clone_method():
+    client = client_factory(build_with="json")
+    client.set_session(sentinel.session)
+    new_client = client.clone()
+    assert new_client.get_session() == client.get_session()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -175,4 +175,4 @@ def test_client_clone_method():
     client = client_factory(build_with="json")
     client.set_session(sentinel.session)
     new_client = client.clone()
-    assert new_client.get_session() == client.get_session()
+    assert new_client.get_session() is client.get_session()

--- a/tests/test_request_strategies.py
+++ b/tests/test_request_strategies.py
@@ -41,6 +41,22 @@ def assert_mock_client_called_once(mock_client, expected_request_data):
     assert mock_client.client.get_request_timeout.call_count == 1
 
 
+def test_request_strategy_sets_session_on_parent_when_not_already_set(mock_client):
+    mock_client.client.get_session.return_value = None
+    strategy = RequestStrategy()
+    strategy.set_client(mock_client.client)
+    mock_client.client.get_session.assert_called_once_with()
+    mock_client.client.set_session.assert_called_once()
+
+
+def test_request_strategy_does_not_set_session_if_already_set(mock_client):
+    mock_client.client.get_session.return_value = sentinel.session
+    strategy = RequestStrategy()
+    strategy.set_client(mock_client.client)
+    mock_client.client.get_session.assert_called_once_with()
+    mock_client.client.set_session.assert_not_called()
+
+
 def test_request_strategy_get_method_delegates_to_parent_handlers(mock_requests, mock_client):
     mock_requests.get("mock://testserver.com", json={"active": True}, status_code=200)
 


### PR DESCRIPTION
- A session is stored on the parent client.  Request strategies can ask
for this session every time they make a request.  This means that a
session can be shared across all requests.  And between requests
strategies including paginators when they are switched temporarily.