### PR TITLE
abstract away the underlying response implementation

### DIFF
--- a/apiclient/response.py
+++ b/apiclient/response.py
@@ -1,0 +1,64 @@
+from typing import Any
+
+import requests
+
+from apiclient.utils.typing import JsonType
+
+
+class Response:
+    """
+    Response abstracts away the underlying response, allowing
+    us to pass around an interface representing the response
+    without any need to knowledge of the underlying http
+    implementation."""
+
+    def get_original(self) -> Any:
+        """Returns the original underlying response object."""
+        raise NotImplementedError
+
+    def get_status_code(self) -> int:
+        """Returns the status code of the response."""
+        raise NotImplementedError
+
+    def get_raw_data(self) -> str:
+        """Returns the content of the response, in unicode."""
+        raise NotImplementedError
+
+    def get_json(self) -> JsonType:
+        """Returns the json-encoded content of a response."""
+        raise NotImplementedError
+
+    def get_status_reason(self) -> str:
+        """Returns the textual representation of an HTTP status code, e.g. "NOT FOUND" or "OK"."""
+        raise NotImplementedError
+
+    def get_requested_url(self) -> str:
+        """Returns the url to which the request was made."""
+        raise NotImplementedError
+
+
+class RequestsResponse(Response):
+    """Implementation of the response for a requests.response type."""
+
+    def __init__(self, response: requests.Response):
+        self._response = response
+
+    def get_original(self) -> Any:
+        return self._response
+
+    def get_status_code(self) -> int:
+        return self._response.status_code
+
+    def get_raw_data(self) -> str:
+        return self._response.text
+
+    def get_json(self) -> JsonType:
+        return self._response.json()
+
+    def get_status_reason(self) -> str:
+        if not self._response.reason:
+            return ""
+        return self._response.reason
+
+    def get_requested_url(self) -> str:
+        return self._response.url

--- a/apiclient/response_handlers.py
+++ b/apiclient/response_handlers.py
@@ -2,9 +2,10 @@ from json import JSONDecodeError
 from typing import Optional
 from xml.etree import ElementTree
 
-from requests import Response
+import requests
 
 from apiclient.exceptions import ResponseParseError
+from apiclient.response import Response
 from apiclient.utils.typing import JsonType, XmlType
 
 
@@ -20,8 +21,8 @@ class RequestsResponseHandler(BaseResponseHandler):
     """Return the original requests response."""
 
     @staticmethod
-    def get_request_data(response: Response) -> Response:
-        return response
+    def get_request_data(response: Response) -> requests.Response:
+        return response.get_original()
 
 
 class JsonResponseHandler(BaseResponseHandler):
@@ -29,14 +30,14 @@ class JsonResponseHandler(BaseResponseHandler):
 
     @staticmethod
     def get_request_data(response: Response) -> Optional[JsonType]:
-        if response.text == "":
+        if response.get_raw_data() == "":
             return None
 
         try:
-            response_json = response.json()
+            response_json = response.get_json()
         except JSONDecodeError as error:
             raise ResponseParseError(
-                f"Unable to decode response data to json. data='{response.text}'"
+                f"Unable to decode response data to json. data='{response.get_raw_data()}'"
             ) from error
         return response_json
 
@@ -46,13 +47,13 @@ class XmlResponseHandler(BaseResponseHandler):
 
     @staticmethod
     def get_request_data(response: Response) -> Optional[XmlType]:
-        if response.text == "":
+        if response.get_raw_data() == "":
             return None
 
         try:
-            xml_element = ElementTree.fromstring(response.text)
+            xml_element = ElementTree.fromstring(response.get_raw_data())
         except ElementTree.ParseError as error:
             raise ResponseParseError(
-                f"Unable to parse response data to xml. data='{response.text}'"
+                f"Unable to parse response data to xml. data='{response.get_raw_data()}'"
             ) from error
         return xml_element

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,11 +2,12 @@ import json as json_lib
 from io import BytesIO
 from unittest.mock import Mock
 
-from requests import Response
+import requests
 
 from apiclient import APIClient, JsonRequestFormatter, JsonResponseHandler, NoAuthentication
 from apiclient.request_formatters import BaseRequestFormatter
 from apiclient.request_strategies import BaseRequestStrategy
+from apiclient.response import RequestsResponse, Response
 from apiclient.response_handlers import BaseResponseHandler
 
 mock_response_handler_call = Mock()
@@ -63,8 +64,8 @@ class NoOpRequestStrategy(BaseRequestStrategy):
 
 
 def build_response(data=None, json=None, status_code: int = 200) -> Response:
-    """Return a requests.Response object with the data set as the content."""
-    response = Response()
+    """Builds a requests.Response object with the data set as the content."""
+    response = requests.Response()
     response.status_code = status_code
     response.headers = {
         "Connection": "keep-alive",
@@ -77,7 +78,7 @@ def build_response(data=None, json=None, status_code: int = 200) -> Response:
     response.raw = BytesIO(bytes(data, encoding="utf-8"))
     response.reason = "OK"
     response.url = "https://jsonplaceholder.typicode.com/todos"
-    return response
+    return RequestsResponse(response)
 
 
 def client_factory(build_with=None, request_strategy=None):

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,0 +1,33 @@
+from unittest.mock import Mock
+
+import pytest
+
+from apiclient.response import RequestsResponse, Response
+
+
+class TestResponse:
+    """Simple tests for 100% coverage - testing abstract class."""
+
+    response = Response()
+
+    @pytest.mark.parametrize(
+        "method",
+        [
+            response.get_original,
+            response.get_status_code,
+            response.get_raw_data,
+            response.get_json,
+            response.get_status_reason,
+            response.get_requested_url,
+        ],
+    )
+    def test_needs_implementation(self, method):
+        with pytest.raises(NotImplementedError):
+            method()
+
+
+class TestRequestsResponse:
+    def test_get_status_reason_returns_empty_string_when_none(self):
+        requests_response = Mock(reason=None)
+        response = RequestsResponse(requests_response)
+        assert response.get_status_reason() == ""

--- a/tests/test_response_handlers.py
+++ b/tests/test_response_handlers.py
@@ -6,6 +6,7 @@ import pytest
 
 from apiclient import JsonResponseHandler, RequestsResponseHandler, XmlResponseHandler
 from apiclient.exceptions import ResponseParseError
+from apiclient.response import RequestsResponse
 from apiclient.response_handlers import BaseResponseHandler
 from tests.helpers import build_response
 
@@ -28,7 +29,7 @@ class TestRequestsResponseHandler:
     handler = RequestsResponseHandler
 
     def test_original_response_is_returned(self):
-        data = self.handler.get_request_data(sentinel.response)
+        data = self.handler.get_request_data(RequestsResponse(sentinel.response))
         assert data == sentinel.response
 
 


### PR DESCRIPTION
Added a new `Response` class that is designed to abstract away the underlying response type (i.e. requests.Response).

This will allow the response to be passed around to other parts of the program and the program can act on the responses interface safely.