### PR TITLE
Change way endpoint decorator gets attributes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Unit Tests
 
 on:
   push:
+  pull_request:
   schedule:
     - cron: '0 0 * * *'
 

--- a/apiclient/decorates.py
+++ b/apiclient/decorates.py
@@ -1,7 +1,5 @@
 import inspect
 
-BASE_URL_ATTR_NAME = "_base_url"
-
 
 def endpoint(cls_=None, base_url=None):
     """Decorator for automatically constructing urls from a base_url and defined resources."""
@@ -23,17 +21,11 @@ def _process_class(cls, base_url):
         )
     else:
         base_url = base_url.rstrip("/")
-        try:
-            super_base_url = getattr(cls, BASE_URL_ATTR_NAME)
-        except AttributeError:
-            super_base_url = ""
-        setattr(cls, BASE_URL_ATTR_NAME, base_url)
 
     for name, value in inspect.getmembers(cls):
         if name.startswith("_") or inspect.ismethod(value) or inspect.isfunction(value):
             # Ignore any private or class attributes.
             continue
-        value = str(value).replace(super_base_url, "")
         new_value = str(value).lstrip("/")
         resource = f"{base_url}/{new_value}"
         setattr(cls, name, resource)

--- a/apiclient/decorates.py
+++ b/apiclient/decorates.py
@@ -1,5 +1,7 @@
 import inspect
 
+BASE_URL_ATTR_NAME = "_base_url"
+
 
 def endpoint(cls_=None, base_url=None):
     """Decorator for automatically constructing urls from a base_url and defined resources."""
@@ -21,11 +23,17 @@ def _process_class(cls, base_url):
         )
     else:
         base_url = base_url.rstrip("/")
+        try:
+            super_base_url = getattr(cls, BASE_URL_ATTR_NAME)
+        except AttributeError:
+            super_base_url = ""
+        setattr(cls, BASE_URL_ATTR_NAME, base_url)
 
     for name, value in inspect.getmembers(cls):
         if name.startswith("_") or inspect.ismethod(value) or inspect.isfunction(value):
             # Ignore any private or class attributes.
             continue
+        value = str(value).replace(super_base_url, "")
         new_value = str(value).lstrip("/")
         resource = f"{base_url}/{new_value}"
         setattr(cls, name, resource)

--- a/apiclient/decorates.py
+++ b/apiclient/decorates.py
@@ -1,3 +1,6 @@
+import inspect
+
+
 def endpoint(cls_=None, base_url=None):
     """Decorator for automatically constructing urls from a base_url and defined resources."""
 
@@ -19,8 +22,8 @@ def _process_class(cls, base_url):
     else:
         base_url = base_url.rstrip("/")
 
-    for name, value in cls.__dict__.items():
-        if name.startswith("_"):
+    for name, value in inspect.getmembers(cls):
+        if name.startswith("_") or inspect.ismethod(value) or inspect.isfunction(value):
             # Ignore any private or class attributes.
             continue
         new_value = str(value).lstrip("/")

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -27,6 +27,15 @@ class EndpointFromEnvironment:
     search = "search"
 
 
+class BaseEndpoint:
+    get_apples = "apples"
+    get_grapes = "grapes"
+
+@endpoint(base_url="https://fruits.com")
+class SubEndpoint(BaseEndpoint):
+    get_hamburgers = "hamburgers"
+
+
 def test_endpoint():
     assert Endpoint.search == "http://foo.com/search"
     assert Endpoint.integer == "http://foo.com/3"
@@ -54,3 +63,9 @@ def test_decorator_does_not_modify_protected_attributes():
 
 def test_decorated_endpoint_loaded_from_environment_variable():
     assert EndpointFromEnvironment.search == "http://environment.com/search"
+
+
+def test_decorator_inherits_attributes():
+    assert SubEndpoint.get_apples == "https://fruits.com/apples"
+    assert SubEndpoint.get_grapes == "https://fruits.com/grapes"
+    assert SubEndpoint.get_hamburgers == "https://fruits.com/hamburgers"

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -27,9 +27,11 @@ class EndpointFromEnvironment:
     search = "search"
 
 
+@endpoint(base_url="https://food.com")
 class BaseEndpoint:
     get_apples = "apples"
     get_grapes = "grapes"
+
 
 @endpoint(base_url="https://fruits.com")
 class SubEndpoint(BaseEndpoint):
@@ -66,6 +68,8 @@ def test_decorated_endpoint_loaded_from_environment_variable():
 
 
 def test_decorator_inherits_attributes():
+    assert BaseEndpoint.get_apples == "https://food.com/apples"
+    assert BaseEndpoint.get_grapes == "https://food.com/grapes"
     assert SubEndpoint.get_apples == "https://fruits.com/apples"
     assert SubEndpoint.get_grapes == "https://fruits.com/grapes"
     assert SubEndpoint.get_hamburgers == "https://fruits.com/hamburgers"

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -27,11 +27,9 @@ class EndpointFromEnvironment:
     search = "search"
 
 
-@endpoint(base_url="https://food.com")
 class BaseEndpoint:
     get_apples = "apples"
     get_grapes = "grapes"
-
 
 @endpoint(base_url="https://fruits.com")
 class SubEndpoint(BaseEndpoint):
@@ -68,8 +66,6 @@ def test_decorated_endpoint_loaded_from_environment_variable():
 
 
 def test_decorator_inherits_attributes():
-    assert BaseEndpoint.get_apples == "https://food.com/apples"
-    assert BaseEndpoint.get_grapes == "https://food.com/grapes"
     assert SubEndpoint.get_apples == "https://fruits.com/apples"
     assert SubEndpoint.get_grapes == "https://fruits.com/grapes"
     assert SubEndpoint.get_hamburgers == "https://fruits.com/hamburgers"

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -31,6 +31,9 @@ class BaseEndpoint:
     get_apples = "apples"
     get_grapes = "grapes"
 
+    def method(self):
+        pass
+
 
 @endpoint(base_url="https://fruits.com")
 class SubEndpoint(BaseEndpoint):

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -31,9 +31,11 @@ class BaseEndpoint:
     get_apples = "apples"
     get_grapes = "grapes"
 
+
 @endpoint(base_url="https://fruits.com")
 class SubEndpoint(BaseEndpoint):
     get_hamburgers = "hamburgers"
+    _ignore_attr = "ignored"
 
 
 def test_endpoint():
@@ -66,6 +68,9 @@ def test_decorated_endpoint_loaded_from_environment_variable():
 
 
 def test_decorator_inherits_attributes():
+    assert BaseEndpoint.get_apples == "apples"
+    assert BaseEndpoint.get_grapes == "grapes"
     assert SubEndpoint.get_apples == "https://fruits.com/apples"
     assert SubEndpoint.get_grapes == "https://fruits.com/grapes"
     assert SubEndpoint.get_hamburgers == "https://fruits.com/hamburgers"
+    assert SubEndpoint._ignore_attr == "ignored"


### PR DESCRIPTION
I tried to create an Endpoint using the endpoint decorator since we use versions with our API, we thought it would be good to have a client for each version of the API, but we came across something peculiar when we tried to inherit our base Endpoint to create an Endpoint for QA and prod with different base_url we noticed that the endpoint decorator didn't find our attributes declared in our base Endpoint, which was kind of frustrating because we needed to repeat our code for the same Endpoint with just different base_url
Example:

    class Endpoint
        get_apples = "apples"
        get_grapes = "grapes"

    @endpoint(base_url="https://fruits.com")
    class EndpointQA(Endpoint):
        pass

In this example the decorator won't be able to find my endpoints defined in the base class