### PR TITLE
tests need to run on prs too

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Unit Tests
 
 on:
   push:
+  pull_request:
   schedule:
     - cron: '0 0 * * *'
 


### PR DESCRIPTION
this means that when created by the owner of the repo, it will trigger multiple runs, but is needed for when someone creates a pr into the repo