### PR TITLE
Allow Class Extension with Custom Attributes in Constructor

### DIFF
--- a/apiclient/client.py
+++ b/apiclient/client.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Any, Optional, Type
+from copy import copy
 
 from apiclient.authentication_methods import BaseAuthenticationMethod, NoAuthentication
 from apiclient.error_handlers import BaseErrorHandler, ErrorHandler
@@ -108,15 +109,7 @@ class APIClient:
 
     def clone(self):
         """Enable Prototype pattern on client."""
-        new_client = type(self)(
-            authentication_method=self.get_authentication_method(),
-            response_handler=self.get_response_handler(),
-            request_formatter=self.get_request_formatter(),
-            error_handler=self.get_error_handler(),
-        )
-        new_client.set_request_strategy(self.get_request_strategy())
-        new_client.set_session(self.get_session())
-        return new_client
+        return copy(self)
 
     def post(self, endpoint: str, data: dict, params: OptionalDict = None, **kwargs):
         """Send data and return response data from POST endpoint."""

--- a/apiclient/client.py
+++ b/apiclient/client.py
@@ -1,6 +1,6 @@
 import logging
-from typing import Any, Optional, Type
 from copy import copy
+from typing import Any, Optional, Type
 
 from apiclient.authentication_methods import BaseAuthenticationMethod, NoAuthentication
 from apiclient.error_handlers import BaseErrorHandler, ErrorHandler

--- a/tests/test_paginators.py
+++ b/tests/test_paginators.py
@@ -20,15 +20,23 @@ def next_page_url(response, previous_page_url):
 
 
 class QueryPaginatedClient(APIClient):
+    def __init__(self, base_url, **kwargs):
+        self.base_url = base_url
+        super().__init__(**kwargs)
+
     @paginated(by_query_params=next_page_param)
     def make_read_request(self):
-        return self.get(endpoint="mock://testserver.com")
+        return self.get(endpoint=self.base_url)
 
 
 class UrlPaginatedClient(APIClient):
+    def __init__(self, base_url, **kwargs):
+        self.base_url = base_url
+        super().__init__(**kwargs)
+
     @paginated(by_url=next_page_url)
     def make_read_request(self):
-        return self.get(endpoint="mock://testserver.com")
+        return self.get(endpoint=self.base_url)
 
 
 def test_query_parameter_pagination(mock_requests):
@@ -48,6 +56,7 @@ def test_query_parameter_pagination(mock_requests):
     )
     # mock_requests.get.side_effect = [build_response(json=page_data) for page_data in response_data]
     client = QueryPaginatedClient(
+        base_url="mock://testserver.com",
         authentication_method=NoAuthentication(),
         response_handler=JsonResponseHandler,
         request_formatter=JsonRequestFormatter,
@@ -81,6 +90,7 @@ def test_url_parameter_pagination(mock_requests):
         {"page2": "data", "next": None},
     ]
     client = UrlPaginatedClient(
+        base_url="mock://testserver.com",
         authentication_method=NoAuthentication(),
         response_handler=JsonResponseHandler,
         request_formatter=JsonRequestFormatter,


### PR DESCRIPTION
The current clone function only clones certain portions of the client for paginators.  If a class is extended with a custom __init__ and attributes, this will fail when the temporary_client is created to retrieve extra pages.  Moved to using standard copy function from Python library for the clone.  Only doing a shallow copy.