### PR TITLE
Fix documented response handler errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ client = ClientImplementation(
 
 ### `JsonResponseHandler`
 Handler that parses the response data to `json` and returns the dictionary.
-If an error occurs trying to parse to json then a `UnexpectedError`
+If an error occurs trying to parse to json then a `ResponseParseError`
 will be raised.
 
 Example:
@@ -353,7 +353,7 @@ client = ClientImplementation(
 
 ### `XmlResponseHandler`
 Handler that parses the response data to an `xml.etree.ElementTree.Element`.
-If an error occurs trying to parse to xml then a `UnexpectedError`
+If an error occurs trying to parse to xml then a `ResponseParseError`
 will be raised.
 
 Example:


### PR DESCRIPTION
Error raised in response handlers changed from `UnexpectedError` to `ResponseParseError` in cfed95f2f9d1cce8565206b845bda9858cb850ec