### PR TITLE
add AsyncAPIClient

### DIFF
--- a/apiclient/__init__.py
+++ b/apiclient/__init__.py
@@ -5,7 +5,7 @@ from apiclient.authentication_methods import (
     NoAuthentication,
     QueryParameterAuthentication,
 )
-from apiclient.client import APIClient
+from apiclient.client import AbstractClient, APIClient, AsyncAPIClient
 from apiclient.decorates import endpoint
 from apiclient.paginators import paginated
 from apiclient.request_formatters import JsonRequestFormatter

--- a/apiclient/authentication_methods.py
+++ b/apiclient/authentication_methods.py
@@ -6,7 +6,7 @@ from apiclient.utils.typing import BasicAuthType, OptionalStr
 if TYPE_CHECKING:  # pragma: no cover
     # Stupid way of getting around cyclic imports when
     # using typehinting.
-    from apiclient import APIClient
+    from apiclient.client import AbstractClient
 
 
 class BaseAuthenticationMethod:
@@ -19,7 +19,7 @@ class BaseAuthenticationMethod:
     def get_username_password_authentication(self) -> Optional[BasicAuthType]:
         return None
 
-    def perform_initial_auth(self, client: "APIClient"):
+    def perform_initial_auth(self, client: "AbstractClient"):
         pass
 
 
@@ -91,7 +91,7 @@ class CookieAuthentication(BaseAuthenticationMethod):
         self._auth_url = auth_url
         self._authentication = authentication
 
-    def perform_initial_auth(self, client: "APIClient"):
+    def perform_initial_auth(self, client: "AbstractClient"):
         client.get(
             self._auth_url,
             headers=self._authentication.get_headers(),

--- a/apiclient/response.py
+++ b/apiclient/response.py
@@ -1,5 +1,7 @@
+import json
 from typing import Any
 
+import aiohttp
 import requests
 
 from apiclient.utils.typing import JsonType
@@ -62,3 +64,26 @@ class RequestsResponse(Response):
 
     def get_requested_url(self) -> str:
         return self._response.url
+
+
+class AioHttpResponse(RequestsResponse):
+    """Implementation of the response for a requests.response type."""
+
+    def __init__(self, response: aiohttp.ClientResponse, content: bytes):
+        self._response = response
+        self._content = content
+        self._text = ""
+
+    def get_status_code(self) -> int:
+        return self._response.status
+
+    def get_raw_data(self) -> str:
+        if not self._text:
+            self._text = self._content.decode(self._response.get_encoding(), errors="strict")
+        return self._text
+
+    def get_json(self) -> JsonType:
+        return json.loads(self._text)
+
+    def get_requested_url(self) -> str:
+        return str(self._response.url)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts = --cov=apiclient/ --cov-fail-under=100 --cov-report html
+addopts = --asyncio-mode=auto --cov=apiclient/ --cov-fail-under=100 --cov-report html
 env =
     ENDPOINT_BASE_URL=http://environment.com
 

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,9 @@
 import setuptools
 
 # Pinning tenacity as the api has changed slightly which breaks all tests.
-application_dependencies = ["requests>=2.16", "tenacity>=5.1.0"]
+application_dependencies = ["requests>=2.16", "aiohttp>=3.8", "tenacity>=5.1.0"]
 prod_dependencies = []
-test_dependencies = ["pytest", "pytest-env", "pytest-cov", "vcrpy", "requests-mock"]
+test_dependencies = ["pytest", "pytest-env", "pytest-cov", "vcrpy", "requests-mock", "pytest-asyncio", "aioresponses"]
 lint_dependencies = ["flake8", "flake8-docstrings", "black", "isort"]
 docs_dependencies = []
 dev_dependencies = test_dependencies + lint_dependencies + docs_dependencies + ["ipdb"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import pytest
 import requests
 import requests_mock
 import vcr
+from aioresponses import aioresponses
 
 from apiclient import APIClient
 from apiclient.request_formatters import BaseRequestFormatter
@@ -70,3 +71,9 @@ def mock_client():
     return MockClient(
         client=_mock_client, request_formatter=mock_request_formatter, response_handler=mock_response_handler
     )
+
+
+@pytest.fixture()
+def mock_aioresponse():
+    with aioresponses() as m:
+        yield m

--- a/tests/integration_tests/client.py
+++ b/tests/integration_tests/client.py
@@ -1,7 +1,7 @@
 from enum import IntEnum, unique
 from json import JSONDecodeError
 
-from apiclient import APIClient, endpoint, paginated, retry_request
+from apiclient import APIClient, AsyncAPIClient, endpoint, paginated, retry_request
 from apiclient.error_handlers import ErrorHandler
 from apiclient.exceptions import APIRequestError
 from apiclient.response import Response
@@ -104,3 +104,33 @@ class Client(APIClient):
     @paginated(by_query_params=by_query_params_callable)
     def list_user_accounts_paginated(self, user_id):
         return self.get(Urls.accounts, params={"userId": user_id})
+
+
+class AsyncClient(AsyncAPIClient):
+    def get_request_timeout(self):
+        return 0.1
+
+    async def list_users(self):
+        return await self.get(Urls.users)
+
+    async def create_user(self, first_name, last_name):
+        data = {"firstName": first_name, "lastName": last_name}
+        return await self.post(Urls.users, data=data)
+
+    async def overwrite_user(self, user_id, first_name, last_name):
+        data = {"firstName": first_name, "lastName": last_name}
+        url = Urls.user.format(id=user_id)
+        return await self.put(url, data=data)
+
+    async def update_user(self, user_id, first_name=None, last_name=None):
+        data = {}
+        if first_name:
+            data["firstName"] = first_name
+        if last_name:
+            data["lastName"] = last_name
+        url = Urls.user.format(id=user_id)
+        return await self.patch(url, data=data)
+
+    async def delete_user(self, user_id):
+        url = Urls.user.format(id=user_id)
+        return await self.delete(url)

--- a/tests/integration_tests/test_async_client_integration.py
+++ b/tests/integration_tests/test_async_client_integration.py
@@ -1,0 +1,69 @@
+import asyncio
+
+import pytest
+
+from apiclient import JsonRequestFormatter, JsonResponseHandler, NoAuthentication
+from apiclient.exceptions import UnexpectedError
+from tests.integration_tests.client import AsyncClient, Urls
+
+
+@pytest.mark.asyncio
+async def test_client_response(mock_aioresponse):
+    mock_aioresponse.get(
+        Urls.users,
+        status=200,
+        payload=[
+            {"userId": 1, "firstName": "Mike", "lastName": "Foo"},
+            {"userId": 2, "firstName": "Sarah", "lastName": "Bar"},
+            {"userId": 3, "firstName": "Barry", "lastName": "Baz"},
+        ],
+    )
+    mock_aioresponse.post(
+        Urls.users, status=201, payload={"userId": 4, "firstName": "Lucy", "lastName": "Qux"}
+    )
+    mock_aioresponse.put(
+        Urls.user.format(id=4), status=200, payload={"userId": 4, "firstName": "Lucy", "lastName": "Foo"}
+    )
+    mock_aioresponse.patch(
+        Urls.user.format(id=4), status=200, payload={"userId": 4, "firstName": "Lucy", "lastName": "Qux"}
+    )
+    mock_aioresponse.delete(Urls.user.format(id=4), status=204, payload=None)
+
+    async with AsyncClient(
+        authentication_method=NoAuthentication(),
+        response_handler=JsonResponseHandler,
+        request_formatter=JsonRequestFormatter,
+    ) as client:
+        responses = await asyncio.gather(
+            client.list_users(),
+            client.create_user(first_name="Lucy", last_name="Qux"),
+            client.overwrite_user(user_id=4, first_name="Lucy", last_name="Foo"),
+            client.update_user(user_id=4, first_name="Lucy", last_name="Qux"),
+            client.delete_user(user_id=4),
+            client.get("mock://testserver"),
+            return_exceptions=True,
+        )
+        # users = await client.list_users()
+        # new_user = await client.create_user(first_name="Lucy", last_name="Qux")
+        # overwritten_user = await client.overwrite_user(user_id=4, first_name="Lucy", last_name="Foo")
+        # updated_user = await client.update_user(user_id=4, first_name="Lucy", last_name="Qux")
+        # deleted_user = await client.delete_user(user_id=4)
+        users, new_user, overwritten_user, updated_user, deleted_user, error = responses
+
+    assert len(users) == 3
+    assert users == [
+        {"userId": 1, "firstName": "Mike", "lastName": "Foo"},
+        {"userId": 2, "firstName": "Sarah", "lastName": "Bar"},
+        {"userId": 3, "firstName": "Barry", "lastName": "Baz"},
+    ]
+
+    assert new_user == {"userId": 4, "firstName": "Lucy", "lastName": "Qux"}
+    assert overwritten_user == {"userId": 4, "firstName": "Lucy", "lastName": "Foo"}
+    assert updated_user == {"userId": 4, "firstName": "Lucy", "lastName": "Qux"}
+    assert deleted_user is None
+
+    assert isinstance(error, UnexpectedError)
+    with pytest.raises(UnexpectedError) as exc_info:
+        async with AsyncClient() as client:
+            await client.get("mock://testserver")
+    assert str(exc_info.value) == "Error when contacting 'mock://testserver'"

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from apiclient.response import RequestsResponse, Response
+from apiclient.response import AioHttpResponse, RequestsResponse, Response
 
 
 class TestResponse:
@@ -31,3 +31,10 @@ class TestRequestsResponse:
         requests_response = Mock(reason=None)
         response = RequestsResponse(requests_response)
         assert response.get_status_reason() == ""
+
+
+class TestAiRequestsResponse:
+    def test_get_url(self):
+        requests_response = Mock(url=1)
+        response = AioHttpResponse(requests_response, b"")
+        assert response.get_requested_url() == "1"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    requests{216,217,218,219,220,221,222,223,224,225,226}-tenacity{51,60,61,62,63,70,80}
+    requests{216,217,218,219,220,221,222,223,224,225,226,227}-tenacity{51,60,61,62,63,70,80}
     lint
 
 [testenv]
@@ -16,6 +16,7 @@ deps =
     requests224: requests>=2.24,<2.25
     requests225: requests>=2.25,<2.26
     requests226: requests>=2.26,<2.27
+    requests227: requests>=2.27,<2.28
     tenacity51: tenacity>=5.1.0,<5.2.0
     tenacity60: tenacity>=6.0.0,<6.1.0
     tenacity61: tenacity>=6.1.0,<6.2.0


### PR DESCRIPTION
An implementation option for an asynchronous api client. 

But it seems to me that in order to optimize the installation of a dependency, it is possible to allow installation separately with requests or / and with aiohttp.

TODO:

- [ ] async pagination
- [ ] test retry async request
- [ ] update README
