### PR TITLE
feat: ship py.typed marker (PEP 561)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 recursive-include apiclient *
 include VERSION
+global-include *.typed
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setuptools.setup(
     url="https://github.com/MikeWooster/api-client",
     python_requires=">=3.10",
     packages=["apiclient"],
+    package_data={"apiclient": ["py.typed"]},
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python :: 3.10",
@@ -41,6 +42,7 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Intended Audience :: Developers",
+        "Typing :: Typed",
     ],
     install_requires=application_dependencies,
     extras_require={


### PR DESCRIPTION
- Adds a `py.typed` marker so downstream type checkers (mypy, pyright) use the package's inline type hints instead of ignoring them.
- Closes #77